### PR TITLE
Fix/timeout when fetching status as read side is stopped

### DIFF
--- a/akka-d3-core/src/main/scala/akka/contrib/d3/readside/ReadSideActor.scala
+++ b/akka-d3-core/src/main/scala/akka/contrib/d3/readside/ReadSideActor.scala
@@ -192,20 +192,6 @@ class ReadSideActor[Event <: AggregateEvent](
     startReceive orElse defaultReceive
   }
 
-  private def stopping(name: String): Receive = {
-    val stoppingReceive: Receive = {
-      case Done ⇒
-        log.info(s"[{}] stopped.", name)
-        unstashAll()
-        context.become(stopped)
-
-      case _ ⇒
-        stash()
-    }
-
-    stoppingReceive orElse defaultReceive
-  }
-
   private def defaultReceive: Receive = {
     case WakeUp(_) ⇒
       log.debug("Waking up")

--- a/akka-d3-core/src/main/scala/akka/contrib/d3/readside/ReadSideActor.scala
+++ b/akka-d3-core/src/main/scala/akka/contrib/d3/readside/ReadSideActor.scala
@@ -173,7 +173,7 @@ class ReadSideActor[Event <: AggregateEvent](
       case EnsureStopped(_) ⇒
         log.info("[{}] stopping.", name)
         shutdown.foreach(_.shutdown())
-        context.become(stopping(name))
+        context.become(stopped)
 
       case AttemptRewind(n, _) if n == processor.name ⇒
         sender ! Status.Failure(new IllegalStateException(s"Can't rewind when active."))


### PR DESCRIPTION
Scenario : 
- Start a readside : OK
- Get the status : OK
- Stop the readside : OK
- Get the status : KO (timeout)